### PR TITLE
Fix theme toggle and JSON typo

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,9 +10,13 @@ let selects = {};
 let categoryObjects = [];
 let promptStructure = {};
 
-document.getElementById('darkmode').addEventListener('change', () => {
-  document.body.classList.toggle('dark-mode', document.getElementById('darkmode').checked);
-});
+function toggleTheme() {
+  const toggle = document.getElementById('darkmode');
+  if (!toggle) return;
+  document.body.classList.toggle('dark-mode', toggle.checked);
+}
+
+document.getElementById('darkmode').addEventListener('change', toggleTheme);
 
 document.getElementById('jsonConfigInput').addEventListener('change', e => {
   const file = e.target.files[0];

--- a/scenes/televangelist_config.json
+++ b/scenes/televangelist_config.json
@@ -15,4 +15,4 @@
     "promptStructure": {
       "base": "A {race}, {ageBracket} televangelist with a {bodyType} build and dressed in {style}, delivers a sermon on {platform} in the {era}. Their delivery is marked by {energy} energy, using {seduction} to reach the audience while asking for {money}."
     }
-  }f
+  }


### PR DESCRIPTION
## Summary
- implement `toggleTheme` in `app.js`
- remove stray character from `televangelist_config.json`

## Testing
- `npx prettier --check .` *(fails: code style issues in other files)*
- `npx eslint .` *(fails: could not find ESLint config)*
- `npx stylelint "**/*.css"` *(fails: command terminated without output)*
- `npm test` *(fails: could not read package.json)*