### PR TITLE
Add JSDOM test for randomizeAll

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,5 +141,10 @@ async function tryLoadConfigFromParam() {
     });
 }
 
-// Initial load
-tryLoadConfigFromParam();
+// Export functions for testing or initialize when running in browser
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { randomizeAll, loadConfig };
+} else {
+  // Initial load
+  tryLoadConfigFromParam();
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};

--- a/js/__tests__/app.test.js
+++ b/js/__tests__/app.test.js
@@ -1,0 +1,39 @@
+const { randomizeAll, loadConfig } = require('../../app.js');
+
+describe('randomizeAll', () => {
+  beforeEach(() => {
+    // Setup minimal DOM elements expected by app.js
+    document.body.innerHTML = `
+      <span id="loadStatus"></span>
+      <span id="errorStatus"></span>
+      <textarea id="output"></textarea>
+      <div id="categoriesContainer"></div>
+      <button id="generateBtn"></button>
+      <button id="randomizeBtn"></button>
+      <button id="copyBtn"></button>
+      <input id="jsonConfigInput" />
+      <input id="darkmode" type="checkbox" />
+      <h1 id="mainTitle"></h1>
+    `;
+  });
+
+  it('randomizes each select within its option range', () => {
+    const config = {
+      categories: [
+        { id: 'animal', options: ['Cat', 'Dog', 'Bird'] },
+        { id: 'color', options: ['Red', 'Green', 'Blue', 'Yellow'] },
+      ],
+      promptStructure: { base: '{animal} {color}' },
+    };
+
+    loadConfig(config);
+    const selects = document.querySelectorAll('#categoriesContainer select');
+
+    randomizeAll();
+
+    selects.forEach(sel => {
+      expect(sel.selectedIndex).toBeGreaterThanOrEqual(0);
+      expect(sel.selectedIndex).toBeLessThan(sel.options.length);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expose `randomizeAll` and `loadConfig` for tests
- configure Jest to use JSDOM
- add `app.test.js` covering `randomizeAll`

## Testing
- *(no automated tests run due to missing Jest installation)*