### PR TITLE
Initialize UI with checks

### DIFF
--- a/codex.html
+++ b/codex.html
@@ -1,173 +1,189 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Codex Viewer</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <style>
-    body {
-      font-family: sans-serif;
-      padding: 2rem;
-    }
-
-    h1 {
-      font-size: 1.8rem;
-      margin-bottom: 1rem;
-    }
-
-    .top-bar {
-      margin-bottom: 2rem;
-    }
-
-    .top-bar a {
-      display: inline-block;
-      padding: 0.5rem 1rem;
-      background-color: #333;
-      color: white;
-      text-decoration: none;
-      border-radius: 4px;
-      font-weight: bold;
-    }
-
-    .top-bar a:hover {
-      background-color: #555;
-    }
-
-    ul {
-      padding: 0;
-      list-style: none;
-    }
-
-    li {
-      margin-bottom: 1.5rem;
-      border-bottom: 1px solid #ccc;
-      padding-bottom: 1rem;
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-    }
-
-    .preview {
-      max-height: 80px;
-      border-radius: 4px;
-    }
-
-    .details {
-      flex-grow: 1;
-    }
-
-    .name-link {
-      font-size: 1.2rem;
-      font-weight: bold;
-      text-decoration: none;
-      color: #333;
-    }
-
-    .name-link:hover {
-      text-decoration: underline;
-    }
-
-    .trait-snippet {
-      font-size: 0.9rem;
-      color: #666;
-      margin-top: 4px;
-    }
-
-    .delete-btn {
-      background-color: #e74c3c;
-      color: white;
-      border: none;
-      border-radius: 4px;
-      padding: 0.4rem 0.7rem;
-      cursor: pointer;
-      font-weight: bold;
-    }
-
-    .delete-btn:hover {
-      background-color: #c0392b;
-    }
-  </style>
-</head>
-<body>
-  <h1>Saved Televangelists</h1>
-
-  <div class="top-bar">
-    <a href="index.html">+ Create New Character</a>
-  </div>
-
-  <ul id="codexList"></ul>
-
-  <script>
-    const list = document.getElementById("codexList");
-
-    function getDossiers() {
-      return JSON.parse(localStorage.getItem("promptlab_dossiers") || "[]");
-    }
-
-    function saveDossiers(dossiers) {
-      localStorage.setItem("promptlab_dossiers", JSON.stringify(dossiers));
-    }
-
-    function deleteDossier(id) {
-      const confirmed = confirm("Are you sure you want to delete this character?");
-      if (!confirmed) return;
-
-      let dossiers = getDossiers();
-      dossiers = dossiers.filter(d => d.id !== id);
-      saveDossiers(dossiers);
-      renderList(); // re-render
-    }
-
-    function renderList() {
-      const dossiers = getDossiers();
-      list.innerHTML = "";
-
-      if (dossiers.length === 0) {
-        list.innerHTML = "<p>No saved characters found.</p>";
-        return;
+  <head>
+    <meta charset="UTF-8" />
+    <title>Codex Viewer</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 2rem;
       }
 
-      dossiers.forEach(d => {
-        const li = document.createElement("li");
+      h1 {
+        font-size: 1.8rem;
+        margin-bottom: 1rem;
+      }
 
-        // Preview image
-        if (d.media && d.media.length > 0) {
-          const img = document.createElement("img");
-          img.src = d.media[0].dataUrl;
-          img.className = "preview";
-          li.appendChild(img);
+      .top-bar {
+        margin-bottom: 2rem;
+      }
+
+      .top-bar a {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        background-color: #333;
+        color: white;
+        text-decoration: none;
+        border-radius: 4px;
+        font-weight: bold;
+      }
+
+      .top-bar a:hover {
+        background-color: #555;
+      }
+
+      ul {
+        padding: 0;
+        list-style: none;
+      }
+
+      li {
+        margin-bottom: 1.5rem;
+        border-bottom: 1px solid #ccc;
+        padding-bottom: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .preview {
+        max-height: 80px;
+        border-radius: 4px;
+      }
+
+      .details {
+        flex-grow: 1;
+      }
+
+      .name-link {
+        font-size: 1.2rem;
+        font-weight: bold;
+        text-decoration: none;
+        color: #333;
+      }
+
+      .name-link:hover {
+        text-decoration: underline;
+      }
+
+      .trait-snippet {
+        font-size: 0.9rem;
+        color: #666;
+        margin-top: 4px;
+      }
+
+      .delete-btn {
+        background-color: #e74c3c;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        padding: 0.4rem 0.7rem;
+        cursor: pointer;
+        font-weight: bold;
+      }
+
+      .delete-btn:hover {
+        background-color: #c0392b;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Saved Televangelists</h1>
+
+    <div class="top-bar">
+      <a href="index.html">+ Create New Character</a>
+    </div>
+
+    <ul id="codexList"></ul>
+
+    <script>
+      let list;
+
+      function getDossiers() {
+        return JSON.parse(localStorage.getItem('promptlab_dossiers') || '[]');
+      }
+
+      function saveDossiers(dossiers) {
+        localStorage.setItem('promptlab_dossiers', JSON.stringify(dossiers));
+      }
+
+      function deleteDossier(id) {
+        const confirmed = confirm(
+          'Are you sure you want to delete this character?'
+        );
+        if (!confirmed) return;
+
+        let dossiers = getDossiers();
+        dossiers = dossiers.filter((d) => d.id !== id);
+        saveDossiers(dossiers);
+        renderList(); // re-render
+      }
+
+      function renderList() {
+        if (!list) return;
+        const dossiers = getDossiers();
+        list.innerHTML = '';
+
+        if (dossiers.length === 0) {
+          list.innerHTML = '<p>No saved characters found.</p>';
+          return;
         }
 
-        // Details block
-        const detailDiv = document.createElement("div");
-        detailDiv.className = "details";
+        dossiers.forEach((d) => {
+          const li = document.createElement('li');
 
-        const link = document.createElement("a");
-        link.href = `dossier.html?id=${encodeURIComponent(d.id)}`;
-        link.className = "name-link";
-        link.textContent = d.name || d.id;
-        detailDiv.appendChild(link);
+          // Preview image
+          if (d.media && d.media.length > 0) {
+            const img = document.createElement('img');
+            img.src = d.media[0].dataUrl;
+            img.className = 'preview';
+            li.appendChild(img);
+          }
 
-        const trait = document.createElement("div");
-        trait.className = "trait-snippet";
-        const summary = d.traits ? `${d.traits.platform || ""}, ${d.traits.era || ""}` : "";
-        trait.textContent = summary;
-        detailDiv.appendChild(trait);
+          // Details block
+          const detailDiv = document.createElement('div');
+          detailDiv.className = 'details';
 
-        li.appendChild(detailDiv);
+          const link = document.createElement('a');
+          link.href = `dossier.html?id=${encodeURIComponent(d.id)}`;
+          link.className = 'name-link';
+          link.textContent = d.name || d.id;
+          detailDiv.appendChild(link);
 
-        // Delete button
-        const delBtn = document.createElement("button");
-        delBtn.className = "delete-btn";
-        delBtn.textContent = "Delete";
-        delBtn.onclick = () => deleteDossier(d.id);
-        li.appendChild(delBtn);
+          const trait = document.createElement('div');
+          trait.className = 'trait-snippet';
+          const summary = d.traits
+            ? `${d.traits.platform || ''}, ${d.traits.era || ''}`
+            : '';
+          trait.textContent = summary;
+          detailDiv.appendChild(trait);
 
-        list.appendChild(li);
-      });
-    }
+          li.appendChild(detailDiv);
 
-    renderList();
-  </script>
-</body>
+          // Delete button
+          const delBtn = document.createElement('button');
+          delBtn.className = 'delete-btn';
+          delBtn.textContent = 'Delete';
+          delBtn.onclick = () => deleteDossier(d.id);
+          li.appendChild(delBtn);
+
+          list.appendChild(li);
+        });
+      }
+
+      function initializeUI() {
+        list = document.getElementById('codexList');
+        renderList();
+      }
+
+      if (typeof window !== 'undefined') {
+        window.addEventListener('DOMContentLoaded', initializeUI);
+      }
+
+      if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { initializeUI };
+      }
+    </script>
+  </body>
 </html>

--- a/dossier.js
+++ b/dossier.js
@@ -1,113 +1,155 @@
 // Example dossier loaded from localStorage or an API
 const dossier = {
-  id: "jebediah_firestorm",
-  name: "Brother Jebediah Firestorm",
+  id: 'jebediah_firestorm',
+  name: 'Brother Jebediah Firestorm',
   traits: {
-    race: "White",
-    ageBracket: "middle-aged",
-    bodyType: "rotund",
-    style: "a white suit with gold lapels",
-    platform: "Facebook Live",
-    era: "the 1990s prosperity gospel boom",
-    energy: "fiery passion",
-    seduction: "promises financial breakthrough for donors",
-    money: "miracle socks for a love gift"
+    race: 'White',
+    ageBracket: 'middle-aged',
+    bodyType: 'rotund',
+    style: 'a white suit with gold lapels',
+    platform: 'Facebook Live',
+    era: 'the 1990s prosperity gospel boom',
+    energy: 'fiery passion',
+    seduction: 'promises financial breakthrough for donors',
+    money: 'miracle socks for a love gift',
   },
   media: [],
   history: [
     {
-      eventId: "start",
-      prompt: "Brother Jebediah Firestorm preaches in a white suit with gold lapels on Facebook Live during the 1990s prosperity gospel boom...",
-      timestamp: "2025-05-15T11:30:00Z"
+      eventId: 'start',
+      prompt:
+        'Brother Jebediah Firestorm preaches in a white suit with gold lapels on Facebook Live during the 1990s prosperity gospel boom...',
+      timestamp: '2025-05-15T11:30:00Z',
     },
     {
-      eventId: "scandal",
-      prompt: "He was caught streaming from the bathroom, sparking scandal.",
-      timestamp: "2025-05-15T11:32:00Z"
-    }
-  ]
+      eventId: 'scandal',
+      prompt: 'He was caught streaming from the bathroom, sparking scandal.',
+      timestamp: '2025-05-15T11:32:00Z',
+    },
+  ],
 };
 
 // Tree structure (simplified here)
 const promptTree = {
   scandal: {
     nextOptions: [
-      { label: "He denies everything.", nextId: "doublingDown" },
-      { label: "He confesses and tries to redeem himself.", nextId: "redemption" }
-    ]
+      { label: 'He denies everything.', nextId: 'doublingDown' },
+      {
+        label: 'He confesses and tries to redeem himself.',
+        nextId: 'redemption',
+      },
+    ],
   },
   redemption: {
-    nextOptions: []
+    nextOptions: [],
   },
   doublingDown: {
-    nextOptions: []
-  }
+    nextOptions: [],
+  },
 };
 
 // Populate dossier
-document.getElementById("characterName").textContent = dossier.name;
+let traitBlock;
+let promptList;
+let imageInput;
+let imageContext;
+let imageGallery;
+let choicesContainer;
 
-// Traits
-const traitBlock = document.getElementById("characterTraits");
-traitBlock.innerHTML = `<h2>Traits</h2><ul>` + Object.entries(dossier.traits)
-  .map(([k, v]) => `<li><strong>${k}</strong>: ${v}</li>`)
-  .join("") + `</ul>`;
+function initializeUI() {
+  const nameEl = document.getElementById('characterName');
+  if (nameEl) nameEl.textContent = dossier.name;
 
-// Prompt history
-const promptList = document.getElementById("promptTimeline");
-promptList.innerHTML = dossier.history.map(h => `<li><strong>${new Date(h.timestamp).toLocaleString()}</strong>: ${h.prompt}</li>`).join("");
+  traitBlock = document.getElementById('characterTraits');
+  if (traitBlock) {
+    traitBlock.innerHTML =
+      `<h2>Traits</h2><ul>` +
+      Object.entries(dossier.traits)
+        .map(([k, v]) => `<li><strong>${k}</strong>: ${v}</li>`)
+        .join('') +
+      `</ul>`;
+  }
+
+  promptList = document.getElementById('promptTimeline');
+  if (promptList) {
+    promptList.innerHTML = dossier.history
+      .map(
+        (h) =>
+          `<li><strong>${new Date(h.timestamp).toLocaleString()}</strong>: ${h.prompt}</li>`
+      )
+      .join('');
+  }
+
+  imageInput = document.getElementById('imageInput');
+  imageContext = document.getElementById('imageContext');
+  imageGallery = document.getElementById('imageGallery');
+  choicesContainer = document.getElementById('choicesContainer');
+
+  renderImages();
+  renderBranchingOptions();
+}
 
 // Images
 function handleImageUpload() {
-  const fileInput = document.getElementById('imageInput');
-  const contextInput = document.getElementById('imageContext');
-  const file = fileInput.files[0];
-  const tag = contextInput.value;
+  if (!imageInput || !imageContext) return;
+  const file = imageInput.files[0];
+  const tag = imageContext.value;
 
-  if (!file || !tag) return alert("Please select a file and add a tag.");
+  if (!file || !tag) return alert('Please select a file and add a tag.');
 
   const reader = new FileReader();
   reader.onload = function (e) {
     dossier.media.push({
       dataUrl: e.target.result,
-      context: tag
+      context: tag,
     });
     renderImages();
-    fileInput.value = '';
-    contextInput.value = '';
+    imageInput.value = '';
+    imageContext.value = '';
   };
   reader.readAsDataURL(file);
 }
 
 function renderImages() {
-  const gallery = document.getElementById("imageGallery");
-  gallery.innerHTML = dossier.media.map(img =>
-    `<div>
+  if (!imageGallery) return;
+  imageGallery.innerHTML = dossier.media
+    .map(
+      (img) => `
+    <div>
       <img class="preview" src="${img.dataUrl}" />
       <div><em>${img.context}</em></div>
     </div>`
-  ).join("");
+    )
+    .join('');
 }
 
 // Choices
 function renderBranchingOptions() {
   const lastEvent = dossier.history[dossier.history.length - 1];
   const options = (promptTree[lastEvent.eventId] || {}).nextOptions || [];
-  const container = document.getElementById("choicesContainer");
+  const container = choicesContainer;
+
+  if (!container) return;
 
   if (options.length === 0) {
-    container.innerHTML = "<p>No further choices defined for this branch.</p>";
+    container.innerHTML = '<p>No further choices defined for this branch.</p>';
     return;
   }
 
-  container.innerHTML = "";
-  options.forEach(opt => {
-    const btn = document.createElement("button");
+  container.innerHTML = '';
+  options.forEach((opt) => {
+    const btn = document.createElement('button');
     btn.textContent = opt.label;
     btn.onclick = () => alert(`Next node would be: ${opt.nextId}`);
     container.appendChild(btn);
   });
 }
 
-renderImages();
-renderBranchingOptions();
+// Export in Node and run in browser
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initializeUI);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { initializeUI };
+}

--- a/home.html
+++ b/home.html
@@ -1,113 +1,176 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>PromptLab Home</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <style>
-    body { font-family: sans-serif; padding: 2rem; }
-    h1 { font-size: 2rem; margin-bottom: 1.5rem; }
-    .section { margin-bottom: 2rem; }
-    .section h2 { font-size: 1.2rem; margin-bottom: 0.5rem; }
-    ul { padding-left: 1rem; }
-    li { margin-bottom: 0.5rem; }
-    a { color: #333; text-decoration: none; font-weight: bold; }
-    a:hover { text-decoration: underline; }
-    #packList { margin-top: 1rem; }
-  </style>
-</head>
-<body>
-  <h1>🎛️ PromptLab Launcher</h1>
-  <div class="section">
-    <h2>Start a Generator</h2>
-    <ul id="packList">
-      <li><a href="index.html?config=/packs/default_config.json">Default Generator</a></li>
-      <li><a href="index.html?config=/packs/televangelist_config.json">Televangelist Generator</a></li>
-    </ul>
-  </div>
-  <div class="section">
-    <h2>View Saved Characters</h2>
-    <a href="codex.html">📖 Open Codex</a>
-  </div>
-  <div class="section">
-    <h2>Import New Prompt Packs</h2>
-    <div id="dropZone" style="border:2px dashed #888; padding:1rem; background:#fafafa; text-align:center; cursor:pointer;">
-      Drag & drop a <code>.json</code> file here to add a new pack.<br>
-      <span id="dropStatus"></span>
-    </div>
-    <p>Uploaded packs are stored in your browser and will appear above automatically.</p>
-  </div>
-  <script>
-    // Drag-and-drop JSON loader for packs
-    const dropZone = document.getElementById('dropZone');
-    const dropStatus = document.getElementById('dropStatus');
-    const packList = document.getElementById('packList');
-
-    function getUserPacks() {
-      return JSON.parse(localStorage.getItem('user_promptlab_packs') || '[]');
-    }
-    function saveUserPacks(packs) {
-      localStorage.setItem('user_promptlab_packs', JSON.stringify(packs));
-    }
-
-    function renderUserPacks() {
-      const packs = getUserPacks();
-      packs.forEach(pack => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = `index.html?config=${encodeURIComponent('userpack:' + pack.id)}`;
-        a.textContent = pack.title || pack.id || 'User Pack';
-        li.appendChild(a);
-        packList.appendChild(li);
-      });
-    }
-
-    // Load user packs at startup
-    renderUserPacks();
-
-    dropZone.addEventListener('dragover', e => {
-      e.preventDefault();
-      dropZone.style.background = '#e0f7fa';
-    });
-    dropZone.addEventListener('dragleave', e => {
-      dropZone.style.background = '#fafafa';
-    });
-    dropZone.addEventListener('drop', e => {
-      e.preventDefault();
-      dropZone.style.background = '#fafafa';
-      const file = e.dataTransfer.files[0];
-      if (!file || !file.name.endsWith('.json')) {
-        dropStatus.textContent = 'Please drop a .json file.';
-        return;
+  <head>
+    <meta charset="UTF-8" />
+    <title>PromptLab Home</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 2rem;
       }
-      const reader = new FileReader();
-      reader.onload = evt => {
-        try {
-          const config = JSON.parse(evt.target.result);
-          if (!config.title) config.title = file.name.replace('.json','');
-          config.id = config.title.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-          const packs = getUserPacks();
-          packs.push(config);
-          saveUserPacks(packs);
-          dropStatus.textContent = `Loaded pack: ${config.title}`;
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1.5rem;
+      }
+      .section {
+        margin-bottom: 2rem;
+      }
+      .section h2 {
+        font-size: 1.2rem;
+        margin-bottom: 0.5rem;
+      }
+      ul {
+        padding-left: 1rem;
+      }
+      li {
+        margin-bottom: 0.5rem;
+      }
+      a {
+        color: #333;
+        text-decoration: none;
+        font-weight: bold;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      #packList {
+        margin-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>🎛️ PromptLab Launcher</h1>
+    <div class="section">
+      <h2>Start a Generator</h2>
+      <ul id="packList">
+        <li>
+          <a href="index.html?config=/packs/default_config.json"
+            >Default Generator</a
+          >
+        </li>
+        <li>
+          <a href="index.html?config=/packs/televangelist_config.json"
+            >Televangelist Generator</a
+          >
+        </li>
+      </ul>
+    </div>
+    <div class="section">
+      <h2>View Saved Characters</h2>
+      <a href="codex.html">📖 Open Codex</a>
+    </div>
+    <div class="section">
+      <h2>Import New Prompt Packs</h2>
+      <div
+        id="dropZone"
+        style="
+          border: 2px dashed #888;
+          padding: 1rem;
+          background: #fafafa;
+          text-align: center;
+          cursor: pointer;
+        "
+      >
+        Drag & drop a <code>.json</code> file here to add a new pack.<br />
+        <span id="dropStatus"></span>
+      </div>
+      <p>
+        Uploaded packs are stored in your browser and will appear above
+        automatically.
+      </p>
+    </div>
+    <script>
+      // Drag-and-drop JSON loader for packs
+      let dropZone;
+      let dropStatus;
+      let packList;
+
+      function getUserPacks() {
+        return JSON.parse(localStorage.getItem('user_promptlab_packs') || '[]');
+      }
+      function saveUserPacks(packs) {
+        localStorage.setItem('user_promptlab_packs', JSON.stringify(packs));
+      }
+
+      function renderUserPacks() {
+        if (!packList) return;
+        const packs = getUserPacks();
+        packs.forEach((pack) => {
           const li = document.createElement('li');
           const a = document.createElement('a');
-          a.href = `index.html?config=${encodeURIComponent('userpack:' + config.id)}`;
-          a.textContent = config.title;
+          a.href = `index.html?config=${encodeURIComponent('userpack:' + pack.id)}`;
+          a.textContent = pack.title || pack.id || 'User Pack';
           li.appendChild(a);
           packList.appendChild(li);
-        } catch (err) {
-          dropStatus.textContent = 'Invalid JSON file.';
-        }
-      };
-      reader.readAsText(file);
-    });
+        });
+      }
 
-    // Support loading user packs in index.html
-    window.getUserPackConfig = function(id) {
-      const packs = getUserPacks();
-      return packs.find(p => p.id === id);
-    };
-  </script>
-</body>
+      function initializeUI() {
+        dropZone = document.getElementById('dropZone');
+        dropStatus = document.getElementById('dropStatus');
+        packList = document.getElementById('packList');
+
+        renderUserPacks();
+
+        if (dropZone) {
+          dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.style.background = '#e0f7fa';
+          });
+          dropZone.addEventListener('dragleave', () => {
+            dropZone.style.background = '#fafafa';
+          });
+          dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.style.background = '#fafafa';
+            const file = e.dataTransfer.files[0];
+            if (!file || !file.name.endsWith('.json')) {
+              if (dropStatus)
+                dropStatus.textContent = 'Please drop a .json file.';
+              return;
+            }
+            const reader = new FileReader();
+            reader.onload = (evt) => {
+              try {
+                const config = JSON.parse(evt.target.result);
+                if (!config.title)
+                  config.title = file.name.replace('.json', '');
+                config.id = config.title
+                  .toLowerCase()
+                  .replace(/[^a-z0-9]+/g, '_');
+                const packs = getUserPacks();
+                packs.push(config);
+                saveUserPacks(packs);
+                if (dropStatus)
+                  dropStatus.textContent = `Loaded pack: ${config.title}`;
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = `index.html?config=${encodeURIComponent('userpack:' + config.id)}`;
+                a.textContent = config.title;
+                li.appendChild(a);
+                packList.appendChild(li);
+              } catch (err) {
+                if (dropStatus) dropStatus.textContent = 'Invalid JSON file.';
+              }
+            };
+            reader.readAsText(file);
+          });
+        }
+
+        window.getUserPackConfig = function (id) {
+          const packs = getUserPacks();
+          return packs.find((p) => p.id === id);
+        };
+      }
+
+      if (typeof window !== 'undefined') {
+        window.addEventListener('DOMContentLoaded', initializeUI);
+      }
+
+      if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { initializeUI };
+      }
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,38 +1,42 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Prompt Generator</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <header>
-    <h1 id="mainTitle">Prompt Generator</h1>
-    <label>
-      <input type="checkbox" id="darkmode" checked onchange="toggleTheme()" />
-      Dark Mode
-    </label>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Prompt Generator</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1 id="mainTitle">Prompt Generator</h1>
+      <label>
+        <input type="checkbox" id="darkmode" checked />
+        Dark Mode
+      </label>
+    </header>
 
-  <section>
-    <label for="jsonConfigInput">Load Configuration JSON:</label>
-    <input type="file" id="jsonConfigInput" accept=".json" />
-    <div id="loadStatus">Loading default config...</div>
-    <div id="errorStatus"></div>
-  </section>
+    <section>
+      <label for="jsonConfigInput">Load Configuration JSON:</label>
+      <input type="file" id="jsonConfigInput" accept=".json" />
+      <div id="loadStatus">Loading default config...</div>
+      <div id="errorStatus"></div>
+    </section>
 
-  <div id="categoriesContainer"></div>
-  <div id="checkboxesContainer"></div>
+    <div id="categoriesContainer"></div>
+    <div id="checkboxesContainer"></div>
 
-  <div class="button-group">
-    <button id="generateBtn">Generate</button>
-    <button id="randomizeBtn">Randomize</button>
-    <button id="copyBtn">Copy</button>
-  </div>
+    <div class="button-group">
+      <button id="generateBtn">Generate</button>
+      <button id="randomizeBtn">Randomize</button>
+      <button id="copyBtn">Copy</button>
+    </div>
 
-  <textarea id="output" rows="10" placeholder="Your generated prompt will appear here..."></textarea>
+    <textarea
+      id="output"
+      rows="10"
+      placeholder="Your generated prompt will appear here..."
+    ></textarea>
 
-  <script src="app.js"></script>
-</body>
+    <script src="app.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap DOM lookups in `initializeUI` for main scripts
- export `initializeUI` for Node and call on page load in browser
- remove inline handler for dark mode toggle

## Testing
- `npx prettier --check app.js dossier.js home.html codex.html index.html`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `npx stylelint "**/*.css"` *(fails: EHOSTUNREACH fetching package)*
- `npm test` *(fails: could not find package.json)*